### PR TITLE
Fix adding to queue on task creation

### DIFF
--- a/taskmaster/static/js/main.js
+++ b/taskmaster/static/js/main.js
@@ -281,8 +281,8 @@ function removeTask(id) {
 function addTask(task) {
   STATE.tasks.push(task.id);
   STATE.taskmap[task.id] = task;
-  if (task.queue) {
-    putTaskInQueue(task.id, task.queue);
+  if (task.queue && STATE.queuemap[task.queue]) {
+    STATE.queuemap[task.queue].tasks.push(task.id);
   }
   FilterTasks.buildTokenSets(STATE.taskmap);
   renderView();


### PR DESCRIPTION
the `putTaskInQueue` method had logic to remove the task from it's existing queue and then made a server call to do the same thing, but since create task was already doing that its existing queue was the one we created it on, so it was getting removed right away.
