### PR TITLE
fix select2 performance issue

### DIFF
--- a/taskmaster/static/css/main.css
+++ b/taskmaster/static/css/main.css
@@ -20,10 +20,20 @@ select.input-sm {
 #s2id_groupSelect, .select2-input, .select2-container, .select2-search-field, .select2-choices {
     width: 100%;
 }
+
 .tag-column {
     max-width: 250px;
     min-width: 100px;
 }
+
+.task-tags-display.no-tags {
+    font-style: italic;
+}
+
+.tag-column.editing .task-tags-display {
+    display: none;
+}
+
 .queue-box {
     margin-bottom: 5px;
 }

--- a/taskmaster/static/js/main.js
+++ b/taskmaster/static/js/main.js
@@ -278,6 +278,10 @@ function setEventHandlers() {
   });
 
 
+  $('body').on('click', function(e) {
+    clearTagInputs();
+  });
+
   $('#logout').on('click', function(e) {
     e.preventDefault();
     e.stopPropagation();
@@ -289,6 +293,12 @@ function setEventHandlers() {
 
     window.location = "/signup";
   });
+}
+
+function clearTagInputs() {
+  // Remove any existing select2 plugins
+  $('.select2-container').select2('destroy');
+  $('.tag-column.editing').removeClass('editing');
 }
 
 function renameQueue(queueId, newName) {
@@ -522,11 +532,12 @@ function renderView() {
   $('.tasks-table tbody tr').click(function(ev) {
     //Stop the details section from opening when selecting stuff
     if ($(ev.target).is('select')) {
-      return false
+      return false;
     }
     if ($(ev.target).hasClass('edit-task-name')) {
-      return true
+      return true;
     }
+
     var tasksTable = $(ev.target).parents('.tasks-table').dataTable();
     if (tasksTable.fnIsOpen(this)) {
       tasksTable.fnClose( this );
@@ -556,25 +567,42 @@ function renderView() {
     $('.create-form-container').toggleClass('hidden');
     STATE.showingCreateTask = !STATE.showingCreateTask;
   });
-  $('.task-tags').select2({
-    placeholder: "Add a tag",
-    tags: STATE.tags
-  }).change(function(val) {
-    var tags = val.val;
-    var taskId = $(this).data('task-id');
-    $.ajax({
-      url: '/task/' + taskId + '/tags',
-      type: 'PUT',
-      data: {
-        value: JSON.stringify(tags)
-      },
-      success: function() {
-        STATE.taskmap[taskId].tags = tags.join(',');
-        newTags = _.difference(tags, STATE.tags);
-        STATE.tags = STATE.tags.concat(newTags);
-        FilterTasks.buildTokenSets(STATE.taskmap);
-      }
+
+  $('.task-tags-display').click(function(evt) {
+    evt.stopPropagation();
+    evt.preventDefault();
+
+    var $this = $(this);
+
+    clearTagInputs();
+
+    var $parent = $this.parent('.tag-column');
+    $parent.addClass('editing');
+    $this.siblings('.task-tags').select2({
+      placeholder: "Add a tag",
+      tags: STATE.tags
+    }).change(function(val) {
+      var tags = val.val;
+      var taskId = $(this).data('task-id');
+      $.ajax({
+        url: '/task/' + taskId + '/tags',
+        type: 'PUT',
+        data: {
+          value: JSON.stringify(tags)
+        },
+        success: function() {
+          STATE.taskmap[taskId].tags = tags.join(',');
+          newTags = _.difference(tags, STATE.tags);
+          STATE.tags = STATE.tags.concat(newTags);
+          FilterTasks.buildTokenSets(STATE.taskmap);
+
+          $this.text(tags);
+        }
+      });
     });
+
+    $parent.find('.select2-search-field input').focus();
+
   });
   $('#task-view tbody').sortable({
     items: '.task-row',
@@ -662,8 +690,18 @@ function renderQueueTasks(queue) {
       });
 
       if (matched) {
+        var tagsDisplay = task.tags.split(',').join(', '),
+            tagsClass = '';
+
+        if(tagsDisplay.length === 0) {
+          tagsDisplay = 'add tags...';
+          tagsClass = 'no-tags';
+        }
+
         var context = $.extend({
-          cssClass: ''
+          cssClass: '',
+          tagsDisplay: tagsDisplay,
+          tagsClass: tagsClass
         }, task);
 
         _.each(styleRules, function(styleRule) {

--- a/taskmaster/templates/_task_row.html
+++ b/taskmaster/templates/_task_row.html
@@ -24,7 +24,10 @@
             <option name='<%= otherQueue.id %>' data-queue-id='<%= otherQueue.id %>' <% if (otherQueue.id===queue) { %>selected<% } %> value='<%= otherQueue.id %>'><%= otherQueue.name %></option>
         <% });  %>
         </select>
-    <td class="tag-column"><input type="hidden" data-task-id="<%= id %>" class="task-tags" value="<%= tags %>"></input></td>
+    <td class="tag-column">
+      <input type="hidden" data-task-id="<%= id %>" class="task-tags" value="<%= tags %>"></input>
+      <div class="task-tags-display <%= tagsClass %>"><%= tagsDisplay %></div>
+      </td>
     <td><span class="glyphicon glyphicon-remove del-task" data-task-id="<%= id %>"></button>
   </tr>
 </script>

--- a/taskmaster/views.py
+++ b/taskmaster/views.py
@@ -274,7 +274,7 @@ def update_task(_id, field):
 @app.route('/order/task', methods=['PUT'])
 @app.route('/order/task/<queue_id>', methods=['PUT'])
 @require_permission('edit_task')
-def update_task_order(queue_id):
+def update_task_order(queue_id=None):
     task_model.update_order(g.org, json.loads(request.form['updates']), queue_id=queue_id)
     return Response(status=200)
 


### PR DESCRIPTION
Only add the select2 plugin when you click on the tags column. Also fixed the bug with re-ordering tasks was just a typo.

The styling is a little weird maybe you can take a look, as you're typing new tags the table width expands and contracts.
